### PR TITLE
Fix/17/crashes profile

### DIFF
--- a/fcfond/main.py
+++ b/fcfond/main.py
@@ -52,12 +52,12 @@ def parse_args():
 
 def main():
     args = parse_args()
+    print(args)
     if args.list != None:
         list_experiments(args.list)
         return
 
     planner = args.planner
-    print('planner',planner)
     if args.pddl != None:
         assert len(args.pddl) % 2 == 0, "Must have an even number of pddl files"
         pddls = [args.pddl[i:i+2] for i in range(0,len(args.pddl),2)]

--- a/fcfond/planner_clingo/fondplus_show.lp
+++ b/fcfond/planner_clingo/fondplus_show.lp
@@ -10,7 +10,7 @@
 #include "fondplus_core.lp".
 
 
-#script(python).
+#script(python)
 def main(prg):
     prg.ground([('base', []),('solucionar', [])])
     prg.solve() # first solving with no show

--- a/fcfond/planner_clingo/fondplus_show_pretty.lp
+++ b/fcfond/planner_clingo/fondplus_show_pretty.lp
@@ -9,7 +9,7 @@ plan(State, Action) :- policy(IdS, IdA), id(state(State), IdS), id(action(Action
 #show plan/2.
 
 
-#script(python).
+#script(python)
 import re
 
 def report_model(m):

--- a/fondpddl/action.py
+++ b/fondpddl/action.py
@@ -174,17 +174,18 @@ class GroundAction:
 
     def encode_clingo(self, problem: Problem, action_index: Index):
         symbols = []
-        index = action_index.get_index(self)
+        index = clingo.Number(action_index.get_index(self))
         symbols.append(clingo.Function('action', [index]))
+
         const_a, const_b = problem.get_fair_constraints(self)
         for constraint in const_a:
-            symbols.append(clingo.Function('con_A', [index, constraint]))
+            symbols.append(clingo.Function('con_A', [index, clingo.Number(constraint)]))
         for constraint in const_b:
-            symbols.append(clingo.Function('con_B', [index, constraint]))
+            symbols.append(clingo.Function('con_B', [index, clingo.Number(constraint)]))
         return symbols
 
     def id_clingo(self, action_index):
-        return clingo.Function('id', [clingo.Function('action',[str(self)]), action_index.get_index(self)])
+        return clingo.Function('id', [clingo.Function('action',[clingo.String(str(self))]), clingo.Number(action_index.get_index(self))])
 
     @staticmethod
     def parse(pddl_tree: PddlTree, actions: List[Action], objects: List[Constant]):

--- a/fondpddl/state.py
+++ b/fondpddl/state.py
@@ -55,7 +55,8 @@ class State:
         print(self.string(problem))
 
     def encode_clingo(self, state_names, action_names):
-        name = state_names.get_index(self)
+        name = clingo.Number(state_names.get_index(self))
+
         symbols = [clingo.Function('state', [name])]
         if self.is_init:
             symbols.append(clingo.Function('initialState', [name]))
@@ -67,11 +68,11 @@ class State:
         for action, states in self.transitions:
             for s in states:
                 symbols.append(clingo.Function('transition',
-                                [name, action_names.get_index(action), state_names.get_index(s)]))
+                                [name, clingo.Number(action_names.get_index(action)), clingo.Number(state_names.get_index(s))]))
         return symbols
 
     def id_clingo(self, state_index, problem):
-        return clingo.Function('id',[clingo.Function('state',[self.string(problem)]), state_index.get_index(self)])
+        return clingo.Function('id', [clingo.Function('state', [clingo.String(self.string(problem))]), clingo.Number(state_index.get_index(self))])
 
     def set_expanded(self):
         self.expanded = True


### PR DESCRIPTION
@idrave 

I installed the latest Clingo 5.5.0 and two things broke:

1. When doing hybrid python+clingo files, the full stop at the end of the # directives caused errors in 5.5.0
2. Clingo 5.5.0 does not do conversion of Python types to their [`Symbols`](https://potassco.org/clingo/python-api/5.5/clingo/symbol.html) anymore. See [here](https://sourceforge.net/p/potassco/mailman/potassco-users/thread/6a80b013a5b2f29b1f558d26a7edbc519f6237f8.camel%40cs.uni-potsdam.de/). 

After some struggled, I fixed them both...

I hope I have done the conversion of all Python data; I changed state, action and conditional fairness parts.